### PR TITLE
Add the English version of the Chinese category pages

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -6,5 +6,7 @@ require 'wikidata/fetcher'
 names_8 = WikiData::Category.new( 'Category:第8屆中華民國立法委員', 'zh').member_titles
 names_9 = WikiData::Category.new( 'Category:第9屆中華民國立法委員', 'zh').member_titles
 
-EveryPolitician::Wikidata.scrape_wikidata(names: { zh: names_8 | names_9 }, output: false)
+names_8_en = WikiData::Category.new( 'Category:Members of the 8th Legislative Yuan', 'en').member_titles
+names_9_en = WikiData::Category.new( 'Category:Members of the 9th Legislative Yuan', 'en').member_titles
 
+EveryPolitician::Wikidata.scrape_wikidata(names: { zh: names_8 | names_9, en: names_8_en | names_9_en }, output: false)


### PR DESCRIPTION
This PR adds the English version of the Chinese Category pages for the 8th and 9th terms of the Legislative Yuan.

This was done because Lee Ching-hua was removed by error from the 8th term in the Chinese category. He appears correctly listed in the English version of that category.
